### PR TITLE
Add project for "Running a Kubernetes ingress"

### DIFF
--- a/create_project.sh
+++ b/create_project.sh
@@ -4,6 +4,6 @@ echo "Project name is $project_name"
 
 mkdir "$project_name"
 
-cp SAMPLE_README.md "$project_name"
+cp SAMPLE_README.md "$project_name/Readme.md"
 
 echo "Created project $project_name"

--- a/running_a_k8s_ingress_kustomize/Readme.md
+++ b/running_a_k8s_ingress_kustomize/Readme.md
@@ -1,0 +1,29 @@
+# Running a Kubernetes ingress (Kustomize edition)
+
+## by [@selamanse](https://github.com/selamanse)
+
+## DESCRIPTION OF PROJECT
+
+Create three types of kubernetes resources
+
+Two deployments of nginx which have different messages when we hit their main endpoint
+Create two services for each of the deployments
+Create a single ingress which redirects to first service on endpoint /first and second endpoint on endpoint /second
+
+## Prerequisites
+
+- nginx ingress controller (if not present [described here](https://docs.rancherdesktop.io/how-to-guides/setup-NGINX-Ingress-Controller/))
+- port forward to ingress controller (if you already have a different one on port 80) `kubectl port-forward --namespace=ingress-nginx service/ingress-nginx-controller 8080:80`
+
+## Steps to run
+
+- `kubectl create ns kube-ingress`
+- `kubectl kustomize kubernetes | kubectl apply -f -`
+- optionally wait for service1: `kubectl wait --for=jsonpath='{.status.readyReplicas}'=2 deployment service1-deployment -n kube-ingress`
+- optionally wait for service2: `kubectl wait --for=jsonpath='{.status.readyReplicas}'=2 deployment service2-deployment -n kube-ingress`
+- `curl http://localhost/first`
+- `curl http://localhost/second`
+
+## ScreenShots
+
+[![asciicast](https://asciinema.org/a/612618.svg)](https://asciinema.org/a/612618)

--- a/running_a_k8s_ingress_kustomize/kubernetes/base/content-configmap.yaml
+++ b/running_a_k8s_ingress_kustomize/kubernetes/base/content-configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-content
+  labels:
+    app: nginx
+data:
+  index.html: |
+    {"Message" : "This is nginx"}

--- a/running_a_k8s_ingress_kustomize/kubernetes/base/deployment.yaml
+++ b/running_a_k8s_ingress_kustomize/kubernetes/base/deployment.yaml
@@ -1,0 +1,30 @@
+# Deployment of nginx
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.25
+          ports:
+            - containerPort: 80
+          volumeMounts:
+            - name: http-content
+              mountPath: /usr/share/nginx/html
+      volumes:
+        - name: http-content
+          configMap:
+            name: nginx-content

--- a/running_a_k8s_ingress_kustomize/kubernetes/base/kustomization.yaml
+++ b/running_a_k8s_ingress_kustomize/kubernetes/base/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+  - deployment.yaml
+  - service.yaml
+  - content-configmap.yaml

--- a/running_a_k8s_ingress_kustomize/kubernetes/base/service.yaml
+++ b/running_a_k8s_ingress_kustomize/kubernetes/base/service.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service
+  labels:
+    app: nginx
+spec:
+  selector:
+    app: nginx
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80

--- a/running_a_k8s_ingress_kustomize/kubernetes/kustomization.yaml
+++ b/running_a_k8s_ingress_kustomize/kubernetes/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+  - ./overlays/service1
+  - ./overlays/service2
+  - ./overlays/ingress
+
+namespace: kube-ingress

--- a/running_a_k8s_ingress_kustomize/kubernetes/out.yaml
+++ b/running_a_k8s_ingress_kustomize/kubernetes/out.yaml
@@ -1,0 +1,92 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: service1
+  namespace: kube-ingress
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app.kubernetes.io/name: service1-deployment
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: service2
+  namespace: kube-ingress
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app.kubernetes.io/name: service2-deployment
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: service1-deployment
+  namespace: kube-ingress
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: service1
+  template:
+    metadata:
+      labels:
+        app: service1
+    spec:
+      containers:
+      - image: nginx:1.25
+        name: nginx
+        ports:
+        - containerPort: 80
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: service2-deployment
+  namespace: kube-ingress
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: service2
+  template:
+    metadata:
+      labels:
+        app: service2
+    spec:
+      containers:
+      - image: nginx:1.25
+        name: nginx
+        ports:
+        - containerPort: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: service1and2
+  namespace: kube-ingress
+spec:
+  ingressClassName: nginx
+  rules:
+  - http:
+      paths:
+      - backend:
+          service:
+            name: service1
+            port:
+              number: 80
+        path: /service1
+        pathType: Prefix
+      - backend:
+          service:
+            name: service2
+            port:
+              number: 80
+        path: /service2
+        pathType: Prefix

--- a/running_a_k8s_ingress_kustomize/kubernetes/overlays/ingress/ingress.yaml
+++ b/running_a_k8s_ingress_kustomize/kubernetes/overlays/ingress/ingress.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: service1and2
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: localhost
+      http:
+        paths:
+          - backend:
+              service:
+                name: service1
+                port:
+                  number: 80
+            path: /first
+            pathType: Prefix
+          - backend:
+              service:
+                name: service2
+                port:
+                  number: 80
+            path: /second
+            pathType: Prefix

--- a/running_a_k8s_ingress_kustomize/kubernetes/overlays/ingress/kustomization.yaml
+++ b/running_a_k8s_ingress_kustomize/kubernetes/overlays/ingress/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - ingress.yaml

--- a/running_a_k8s_ingress_kustomize/kubernetes/overlays/service1/kustomization.yaml
+++ b/running_a_k8s_ingress_kustomize/kubernetes/overlays/service1/kustomization.yaml
@@ -1,0 +1,16 @@
+resources:
+  - ../../base
+
+patches:
+  - path: patch-deployment.yaml
+    target:
+      kind: Deployment
+      name: nginx-deployment
+  - path: patch-service.yaml
+    target:
+      kind: Service
+      name: nginx-service
+  - path: patch-content.yaml
+    target:
+      kind: ConfigMap
+      name: nginx-content

--- a/running_a_k8s_ingress_kustomize/kubernetes/overlays/service1/patch-content.yaml
+++ b/running_a_k8s_ingress_kustomize/kubernetes/overlays/service1/patch-content.yaml
@@ -1,0 +1,9 @@
+- op: replace
+  path: /metadata/name
+  value: service1-content
+- op: replace
+  path: /metadata/labels/app
+  value: service1-content
+- op: replace
+  path: /data/index.html
+  value: '{"Message" : "This is service 1"}'

--- a/running_a_k8s_ingress_kustomize/kubernetes/overlays/service1/patch-deployment.yaml
+++ b/running_a_k8s_ingress_kustomize/kubernetes/overlays/service1/patch-deployment.yaml
@@ -1,0 +1,15 @@
+- op: replace
+  path: /metadata/name
+  value: service1-deployment
+- op: replace
+  path: /metadata/labels/app
+  value: service1
+- op: replace
+  path: /spec/selector/matchLabels/app
+  value: service1
+- op: replace
+  path: /spec/template/metadata/labels/app
+  value: service1
+- op: replace
+  path: /spec/template/spec/volumes/0/configMap/name
+  value: service1-content

--- a/running_a_k8s_ingress_kustomize/kubernetes/overlays/service1/patch-service.yaml
+++ b/running_a_k8s_ingress_kustomize/kubernetes/overlays/service1/patch-service.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /metadata/name
+  value: service1
+- op: replace
+  path: /spec/selector/app
+  value: service1

--- a/running_a_k8s_ingress_kustomize/kubernetes/overlays/service2/kustomization.yaml
+++ b/running_a_k8s_ingress_kustomize/kubernetes/overlays/service2/kustomization.yaml
@@ -1,0 +1,16 @@
+resources:
+  - ../../base
+
+patches:
+  - path: patch-deployment.yaml
+    target:
+      kind: Deployment
+      name: nginx-deployment
+  - path: patch-service.yaml
+    target:
+      kind: Service
+      name: nginx-service
+  - path: patch-content.yaml
+    target:
+      kind: ConfigMap
+      name: nginx-content

--- a/running_a_k8s_ingress_kustomize/kubernetes/overlays/service2/patch-content.yaml
+++ b/running_a_k8s_ingress_kustomize/kubernetes/overlays/service2/patch-content.yaml
@@ -1,0 +1,9 @@
+- op: replace
+  path: /metadata/name
+  value: service2-content
+- op: replace
+  path: /metadata/labels/app
+  value: service2-content
+- op: replace
+  path: /data/index.html
+  value: '{"Message" : "This is service 2"}'

--- a/running_a_k8s_ingress_kustomize/kubernetes/overlays/service2/patch-deployment.yaml
+++ b/running_a_k8s_ingress_kustomize/kubernetes/overlays/service2/patch-deployment.yaml
@@ -1,0 +1,15 @@
+- op: replace
+  path: /metadata/name
+  value: service2-deployment
+- op: replace
+  path: /metadata/labels/app
+  value: service2
+- op: replace
+  path: /spec/selector/matchLabels/app
+  value: service2
+- op: replace
+  path: /spec/template/metadata/labels/app
+  value: service2
+- op: replace
+  path: /spec/template/spec/volumes/0/configMap/name
+  value: service2-content

--- a/running_a_k8s_ingress_kustomize/kubernetes/overlays/service2/patch-service.yaml
+++ b/running_a_k8s_ingress_kustomize/kubernetes/overlays/service2/patch-service.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /metadata/name
+  value: service2
+- op: replace
+  path: /spec/selector/app
+  value: service2


### PR DESCRIPTION
This change adds:

- A project setup as described in the contrib documentation for "Running a Kubernetes ingress" #5 

Also this change modifies:

- the project setup script minimally to have the sample readme correctly named "Readme.md" in the new project
- the project setup script to be executable

